### PR TITLE
[feat] 사용자 온보딩 정보

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework:spring-webflux'
+
+	implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
 }
 
 def querydslDir = "$buildDir/generated"

--- a/src/main/java/sopt/jeolloga/domain/auth/jwt/CustomUserDetails.java
+++ b/src/main/java/sopt/jeolloga/domain/auth/jwt/CustomUserDetails.java
@@ -1,0 +1,38 @@
+package sopt.jeolloga.domain.auth.jwt;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final Long userId;
+
+    public CustomUserDetails(Long userId) {
+        this.userId = userId;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(userId);
+    }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}

--- a/src/main/java/sopt/jeolloga/domain/auth/jwt/JwtTokenGenerator.java
+++ b/src/main/java/sopt/jeolloga/domain/auth/jwt/JwtTokenGenerator.java
@@ -26,7 +26,8 @@ public class JwtTokenGenerator {
                 .getBody();
 
         Long userId = Long.parseLong(claims.getSubject());
-        return new UsernamePasswordAuthenticationToken(userId, "", List.of());
+        CustomUserDetails userDetails = new CustomUserDetails(userId);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 
     public Long extractUserId(String token) {

--- a/src/main/java/sopt/jeolloga/domain/member/Member.java
+++ b/src/main/java/sopt/jeolloga/domain/member/Member.java
@@ -2,6 +2,8 @@ package sopt.jeolloga.domain.member;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import sopt.jeolloga.exception.BusinessErrorCode;
+import sopt.jeolloga.exception.BusinessException;
 
 @Entity
 @Getter
@@ -30,13 +32,13 @@ public class Member {
     private String religion;
 
     @Column
-    private boolean hasExperience;
+    private String hasExperience;
 
     protected Member() {
 
     }
 
-    public Member(String nickname, String email, String ageRange, String gender, String religion, boolean hasExperience) {
+    public Member(String nickname, String email, String ageRange, String gender, String religion, String hasExperience) {
         this.nickname = nickname;
         this.email = email;
         this.ageRange = ageRange;
@@ -49,5 +51,12 @@ public class Member {
         this.kakaoUserId = kakaoUserId;
         this.email = email;
         this.nickname = nickname;
+    }
+
+    public void onboard(String ageRange, String gender, String religion, String hasExperience) {
+        this.ageRange = ageRange;
+        this.gender = gender;
+        this.religion = religion;
+        this.hasExperience = hasExperience;
     }
 }

--- a/src/main/java/sopt/jeolloga/domain/member/api/MemberController.java
+++ b/src/main/java/sopt/jeolloga/domain/member/api/MemberController.java
@@ -1,14 +1,32 @@
 package sopt.jeolloga.domain.member.api;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sopt.jeolloga.common.dto.ApiResponse;
+import sopt.jeolloga.domain.auth.jwt.CustomUserDetails;
+import sopt.jeolloga.domain.member.api.dto.req.MemberOnboardingReq;
 import sopt.jeolloga.domain.member.core.MemberService;
+import jakarta.validation.Valid;
 
 @RestController
+@RequestMapping("/user")
 public class MemberController {
     private final MemberService memberService;
 
     public MemberController(MemberService memberService) {
         this.memberService = memberService;
+    }
+
+    @PostMapping("/onboarding")
+    public ResponseEntity<ApiResponse<?>> createOnboarding(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody MemberOnboardingReq memberOnboardingReq
+    ) {
+        memberService.createOnboarding(userDetails.getUserId(), memberOnboardingReq);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/sopt/jeolloga/domain/member/api/dto/req/MemberOnboardingReq.java
+++ b/src/main/java/sopt/jeolloga/domain/member/api/dto/req/MemberOnboardingReq.java
@@ -1,0 +1,11 @@
+package sopt.jeolloga.domain.member.api.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberOnboardingReq(
+        @NotBlank(message = "나이대는 필수입니다.") String ageRange,
+        @NotBlank(message = "성별은 필수입니다.") String gender,
+        @NotBlank(message = "종교 정보는 필수입니다.") String religion,
+        @NotBlank(message = "템플스테이 경험 여부는 필수입니다.") String hasExperience
+) {
+}

--- a/src/main/java/sopt/jeolloga/domain/member/core/MemberService.java
+++ b/src/main/java/sopt/jeolloga/domain/member/core/MemberService.java
@@ -1,7 +1,12 @@
 package sopt.jeolloga.domain.member.core;
 
 import org.springframework.stereotype.Service;
+import sopt.jeolloga.domain.member.Member;
+import sopt.jeolloga.domain.member.api.dto.req.MemberOnboardingReq;
 import sopt.jeolloga.domain.member.core.MemberRepository;
+import sopt.jeolloga.exception.BusinessErrorCode;
+import sopt.jeolloga.exception.BusinessException;
+import sopt.jeolloga.exception.ErrorCode;
 
 @Service
 public class MemberService {
@@ -9,5 +14,16 @@ public class MemberService {
 
     public MemberService(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
+    }
+
+    public void createOnboarding(Long userId, MemberOnboardingReq memberOnboardingReq) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.NOT_FOUND_USER));
+        member.onboard(
+                memberOnboardingReq.ageRange(),
+                memberOnboardingReq.gender(),
+                memberOnboardingReq.religion(),
+                memberOnboardingReq.hasExperience()
+        );
     }
 }


### PR DESCRIPTION
## 📝 Work Description
- Issue close #27'

## 🔨 Changes
- 인증된 사용자만 온보딩 정보 입력할수있도록 설정


## 💡 To Reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 사용자 온보딩을 위한 REST API 엔드포인트가 추가되었습니다. 이제 사용자는 나이대, 성별, 종교, 템플스테이 경험 여부를 입력하여 온보딩 정보를 등록할 수 있습니다.
- **기타 변경 사항**
  - 온보딩 요청 시 필수 입력값(나이대, 성별, 종교, 경험 여부)에 대한 유효성 검사가 강화되었습니다.
  - 회원 정보의 템플스테이 경험 여부 필드가 boolean에서 문자열로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->