### PR TITLE
[feat] 사용자 정보 반환

### DIFF
--- a/src/main/java/sopt/jeolloga/domain/member/Member.java
+++ b/src/main/java/sopt/jeolloga/domain/member/Member.java
@@ -32,13 +32,13 @@ public class Member {
     private String religion;
 
     @Column
-    private String hasExperience;
+    private boolean hasExperience;
 
     protected Member() {
 
     }
 
-    public Member(String nickname, String email, String ageRange, String gender, String religion, String hasExperience) {
+    public Member(String nickname, String email, String ageRange, String gender, String religion, boolean hasExperience) {
         this.nickname = nickname;
         this.email = email;
         this.ageRange = ageRange;
@@ -53,7 +53,7 @@ public class Member {
         this.nickname = nickname;
     }
 
-    public void onboard(String ageRange, String gender, String religion, String hasExperience) {
+    public void onboard(String ageRange, String gender, String religion, boolean hasExperience) {
         this.ageRange = ageRange;
         this.gender = gender;
         this.religion = religion;

--- a/src/main/java/sopt/jeolloga/domain/member/api/MemberController.java
+++ b/src/main/java/sopt/jeolloga/domain/member/api/MemberController.java
@@ -2,13 +2,11 @@ package sopt.jeolloga.domain.member.api;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import sopt.jeolloga.common.dto.ApiResponse;
 import sopt.jeolloga.domain.auth.jwt.CustomUserDetails;
 import sopt.jeolloga.domain.member.api.dto.req.MemberOnboardingReq;
+import sopt.jeolloga.domain.member.api.dto.res.MemberOnboardingRes;
 import sopt.jeolloga.domain.member.core.MemberService;
 import jakarta.validation.Valid;
 
@@ -28,5 +26,13 @@ public class MemberController {
     ) {
         memberService.createOnboarding(userDetails.getUserId(), memberOnboardingReq);
         return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @GetMapping("/mypage")
+    public ResponseEntity<ApiResponse<?>> getMemberInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+            ) {
+        MemberOnboardingRes memberOnboardingRes = memberService.getMemberInfo(userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.success(memberOnboardingRes));
     }
 }

--- a/src/main/java/sopt/jeolloga/domain/member/api/dto/req/MemberOnboardingReq.java
+++ b/src/main/java/sopt/jeolloga/domain/member/api/dto/req/MemberOnboardingReq.java
@@ -1,11 +1,12 @@
 package sopt.jeolloga.domain.member.api.dto.req;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record MemberOnboardingReq(
         @NotBlank(message = "나이대는 필수입니다.") String ageRange,
         @NotBlank(message = "성별은 필수입니다.") String gender,
         @NotBlank(message = "종교 정보는 필수입니다.") String religion,
-        @NotBlank(message = "템플스테이 경험 여부는 필수입니다.") boolean hasExperience
+        @NotNull(message = "템플스테이 경험 여부는 필수입니다.") boolean hasExperience
 ) {
 }

--- a/src/main/java/sopt/jeolloga/domain/member/api/dto/req/MemberOnboardingReq.java
+++ b/src/main/java/sopt/jeolloga/domain/member/api/dto/req/MemberOnboardingReq.java
@@ -6,6 +6,6 @@ public record MemberOnboardingReq(
         @NotBlank(message = "나이대는 필수입니다.") String ageRange,
         @NotBlank(message = "성별은 필수입니다.") String gender,
         @NotBlank(message = "종교 정보는 필수입니다.") String religion,
-        @NotBlank(message = "템플스테이 경험 여부는 필수입니다.") String hasExperience
+        @NotBlank(message = "템플스테이 경험 여부는 필수입니다.") boolean hasExperience
 ) {
 }

--- a/src/main/java/sopt/jeolloga/domain/member/api/dto/res/MemberOnboardingRes.java
+++ b/src/main/java/sopt/jeolloga/domain/member/api/dto/res/MemberOnboardingRes.java
@@ -1,0 +1,25 @@
+package sopt.jeolloga.domain.member.api.dto.res;
+
+import sopt.jeolloga.domain.member.Member;
+
+public record MemberOnboardingRes(
+        Long userId,
+        String nickname,
+        String email,
+        String ageRange,
+        String gender,
+        String religion,
+        boolean hasExperience
+) {
+    public static MemberOnboardingRes from(Member member) {
+        return new MemberOnboardingRes(
+                member.getId(),
+                member.getNickname(),
+                member.getEmail(),
+                member.getAgeRange(),
+                member.getGender(),
+                member.getReligion(),
+                member.isHasExperience()
+        );
+    }
+}

--- a/src/main/java/sopt/jeolloga/domain/member/core/MemberService.java
+++ b/src/main/java/sopt/jeolloga/domain/member/core/MemberService.java
@@ -3,6 +3,7 @@ package sopt.jeolloga.domain.member.core;
 import org.springframework.stereotype.Service;
 import sopt.jeolloga.domain.member.Member;
 import sopt.jeolloga.domain.member.api.dto.req.MemberOnboardingReq;
+import sopt.jeolloga.domain.member.api.dto.res.MemberOnboardingRes;
 import sopt.jeolloga.domain.member.core.MemberRepository;
 import sopt.jeolloga.exception.BusinessErrorCode;
 import sopt.jeolloga.exception.BusinessException;
@@ -25,5 +26,11 @@ public class MemberService {
                 memberOnboardingReq.religion(),
                 memberOnboardingReq.hasExperience()
         );
+    }
+
+    public MemberOnboardingRes getMemberInfo(Long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.NOT_FOUND_USER));
+        return MemberOnboardingRes.from(member);
     }
 }


### PR DESCRIPTION
## 📝 Work Description
- Issue close #29 

## 🔨 Changes
- 사용자 정보 반환.
- 클라이언트는 쿠키만 보내고 서버가 쿠키의 토큰을 조회하여 사용자 아이디 추출 후 해당 사용자의 정보를 반환 

## 💡 To Reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 마이페이지에서 회원 정보를 조회할 수 있는 GET /user/mypage 엔드포인트가 추가되었습니다.

- **버그 수정**
  - 회원의 템플스테이 경험 여부 필드가 String에서 boolean 타입으로 변경되어 입력 및 응답의 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->