### PR TITLE
[feat] 검색어 리스트 반환

### DIFF
--- a/src/main/java/sopt/jeolloga/config/SecurityConfig.java
+++ b/src/main/java/sopt/jeolloga/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
                                 "/v2/api/templestay/recommendation",
                                 "/v2/api/templestay/details/**"
                         ).permitAll()
-                        .requestMatchers("/api/user/**", "/v2/user/**").authenticated()
+                        .requestMatchers("/user/**", "/v2/user/**").authenticated()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/sopt/jeolloga/domain/auth/jwt/JwtCookieProvider.java
+++ b/src/main/java/sopt/jeolloga/domain/auth/jwt/JwtCookieProvider.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 import sopt.jeolloga.domain.auth.dto.LoginResult;
-import sopt.jeolloga.domain.auth.kakao.RedirectUriResolver;
+import sopt.jeolloga.exception.JwtAuthenticationException;
 
 import java.util.Arrays;
 import java.util.List;
@@ -20,7 +20,11 @@ public class JwtCookieProvider {
     private static final String KAKAO_TOKEN_NAME = "kakaoAccessToken";
 
     public String extractAccessToken(HttpServletRequest request) {
-        return extractCookie(request, ACCESS_TOKEN_NAME);
+        String token = extractCookie(request, ACCESS_TOKEN_NAME);
+        if (token == null || token.isBlank()) {
+            throw new JwtAuthenticationException("Access Token 누락");
+        }
+        return token;
     }
 
     public String extractRefreshToken(HttpServletRequest request) {

--- a/src/main/java/sopt/jeolloga/domain/auth/jwt/JwtTokenGenerator.java
+++ b/src/main/java/sopt/jeolloga/domain/auth/jwt/JwtTokenGenerator.java
@@ -1,12 +1,14 @@
 package sopt.jeolloga.domain.auth.jwt;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
+import sopt.jeolloga.exception.CustomAuthenticationEntryPoint;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -31,13 +33,18 @@ public class JwtTokenGenerator {
     }
 
     public Long extractUserId(String token) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(jwtProperties.secret().getBytes(StandardCharsets.UTF_8))
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(jwtProperties.secret().getBytes(StandardCharsets.UTF_8))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
 
-        return Long.parseLong(claims.getSubject());
+            return Long.parseLong(claims.getSubject());
+
+        } catch (JwtException ex) {
+            throw ex;
+        }
     }
 
     public String generateRefreshToken(Long userId) {

--- a/src/main/java/sopt/jeolloga/domain/search/api/controller/SearchController.java
+++ b/src/main/java/sopt/jeolloga/domain/search/api/controller/SearchController.java
@@ -1,13 +1,38 @@
 package sopt.jeolloga.domain.search.api.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sopt.jeolloga.common.dto.ApiResponse;
+import sopt.jeolloga.domain.auth.jwt.JwtCookieProvider;
+import sopt.jeolloga.domain.auth.jwt.JwtTokenGenerator;
+import sopt.jeolloga.domain.search.api.dto.res.SearchListRes;
 import sopt.jeolloga.domain.search.core.SearchService;
 
 @RestController
+@RequestMapping("/user")
 public class SearchController {
     private final SearchService searchService;
+    private final JwtCookieProvider jwtCookieProvider;
+    private final JwtTokenGenerator jwtTokenGenerator;
 
-    public SearchController(SearchService searchService) {
+    public SearchController(SearchService searchService, JwtCookieProvider jwtCookieProvider, JwtTokenGenerator jwtTokenGenerator) {
         this.searchService = searchService;
+        this.jwtCookieProvider = jwtCookieProvider;
+        this.jwtTokenGenerator = jwtTokenGenerator;
+    }
+
+    @GetMapping("search-list")
+    public ResponseEntity<ApiResponse<?>> getSearch(
+        HttpServletRequest request
+    ) {
+        String accessToken = jwtCookieProvider.extractAccessToken(request);
+        Long userId = jwtTokenGenerator.extractUserId(accessToken);
+
+        SearchListRes response = searchService.getSearch(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/sopt/jeolloga/domain/search/api/dto/SearchDto.java
+++ b/src/main/java/sopt/jeolloga/domain/search/api/dto/SearchDto.java
@@ -1,0 +1,7 @@
+package sopt.jeolloga.domain.search.api.dto;
+
+public record SearchDto(
+        Long searchId,
+        String search
+) {
+}

--- a/src/main/java/sopt/jeolloga/domain/search/api/dto/res/SearchListRes.java
+++ b/src/main/java/sopt/jeolloga/domain/search/api/dto/res/SearchListRes.java
@@ -1,0 +1,10 @@
+package sopt.jeolloga.domain.search.api.dto.res;
+
+import sopt.jeolloga.domain.search.api.dto.SearchDto;
+
+import java.util.List;
+
+public record SearchListRes(
+        List<SearchDto> searchList
+) {
+}

--- a/src/main/java/sopt/jeolloga/domain/search/core/SearchRepository.java
+++ b/src/main/java/sopt/jeolloga/domain/search/core/SearchRepository.java
@@ -2,9 +2,17 @@ package sopt.jeolloga.domain.search.core;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import sopt.jeolloga.domain.member.Member;
 import sopt.jeolloga.domain.search.Search;
+
+import java.util.List;
 
 @Repository
 public interface SearchRepository extends JpaRepository<Search, Long> {
 
+    void deleteByMemberAndContent(Member member, String content);
+
+    List<Search> findByMemberOrderByIdDesc(Member member);
+
+    List<Search> findTop10ByMember_IdOrderByIdDesc(Long memberId);
 }

--- a/src/main/java/sopt/jeolloga/domain/search/core/SearchRepository.java
+++ b/src/main/java/sopt/jeolloga/domain/search/core/SearchRepository.java
@@ -1,6 +1,9 @@
 package sopt.jeolloga.domain.search.core;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import sopt.jeolloga.domain.member.Member;
 import sopt.jeolloga.domain.search.Search;
@@ -12,7 +15,18 @@ public interface SearchRepository extends JpaRepository<Search, Long> {
 
     void deleteByMemberAndContent(Member member, String content);
 
-    List<Search> findByMemberOrderByIdDesc(Member member);
-
     List<Search> findTop10ByMember_IdOrderByIdDesc(Long memberId);
+
+    @Modifying
+    @Query("""
+        DELETE FROM Search s
+        WHERE s.member = :member
+        AND s.id NOT IN (
+            SELECT s2.id FROM Search s2
+            WHERE s2.member = :member
+            ORDER BY s2.id DESC
+            LIMIT :limit
+        )
+    """)
+    void deleteOldSearchesBeyondLimit(@Param("member") Member member, @Param("limit") int limit);
 }

--- a/src/main/java/sopt/jeolloga/domain/search/core/SearchService.java
+++ b/src/main/java/sopt/jeolloga/domain/search/core/SearchService.java
@@ -1,12 +1,49 @@
 package sopt.jeolloga.domain.search.core;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sopt.jeolloga.domain.member.Member;
+import sopt.jeolloga.domain.member.core.MemberRepository;
+import sopt.jeolloga.domain.search.Search;
+import sopt.jeolloga.domain.search.api.dto.SearchDto;
+import sopt.jeolloga.domain.search.api.dto.res.SearchListRes;
+import sopt.jeolloga.exception.BusinessErrorCode;
+import sopt.jeolloga.exception.BusinessException;
+
+import java.util.List;
 
 @Service
 public class SearchService {
     private final SearchRepository searchRepository;
+    private final MemberRepository memberRepository;
 
-    public SearchService(SearchRepository searchRepository) {
+    public SearchService(SearchRepository searchRepository, MemberRepository memberRepository) {
         this.searchRepository = searchRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public void saveSearch(Long userId, String keyword) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.NOT_FOUND_USER));
+
+        searchRepository.deleteByMemberAndContent(member, keyword);
+
+        searchRepository.save(new Search(member, keyword));
+
+        List<Search> all = searchRepository.findByMemberOrderByIdDesc(member);
+        if (all.size() > 10) {
+            searchRepository.deleteAll(all.subList(10, all.size()));
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public SearchListRes getSearch(Long userId) {
+        List<SearchDto> list = searchRepository.findTop10ByMember_IdOrderByIdDesc(userId)
+                .stream()
+                .map(s -> new SearchDto(s.getId(), s.getContent()))
+                .toList();
+
+        return new SearchListRes(list);
     }
 }

--- a/src/main/java/sopt/jeolloga/domain/search/core/SearchService.java
+++ b/src/main/java/sopt/jeolloga/domain/search/core/SearchService.java
@@ -28,13 +28,9 @@ public class SearchService {
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.NOT_FOUND_USER));
 
         searchRepository.deleteByMemberAndContent(member, keyword);
-
         searchRepository.save(new Search(member, keyword));
 
-        List<Search> all = searchRepository.findByMemberOrderByIdDesc(member);
-        if (all.size() > 10) {
-            searchRepository.deleteAll(all.subList(10, all.size()));
-        }
+        searchRepository.deleteOldSearchesBeyondLimit(member, 10);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/sopt/jeolloga/domain/templestay/core/TemplestayService.java
+++ b/src/main/java/sopt/jeolloga/domain/templestay/core/TemplestayService.java
@@ -8,8 +8,8 @@ import sopt.jeolloga.common.filter.*;
 import sopt.jeolloga.domain.auth.jwt.CustomUserDetails;
 import sopt.jeolloga.domain.image.core.ImageRepository;
 import sopt.jeolloga.domain.member.core.MemberRepository;
-import sopt.jeolloga.domain.search.Search;
 import sopt.jeolloga.domain.search.core.SearchRepository;
+import sopt.jeolloga.domain.search.core.SearchService;
 import sopt.jeolloga.domain.templestay.Templestay;
 import sopt.jeolloga.domain.templestay.api.dto.*;
 import sopt.jeolloga.domain.templestay.core.repository.TemplestayRepository;
@@ -36,9 +36,8 @@ public class TemplestayService {
     private final TemplestayRepository templestayRepository;
     private final ImageRepository imageRepository;
     private final TemplestayRecommendMapper templestayRecommendMapper;
-    private final SearchRepository searchRepository;
+    private final SearchService searchService;
     private final WishlistRepository wishlistRepository;
-    private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
     public TemplestayRecommendListRes getRecommendTemplestays(Long userId) {
@@ -91,9 +90,7 @@ public class TemplestayService {
         int etcMask = FilterMaskUtil.combineMasks(etc);
 
         if (user != null && search != null && !search.isBlank()) {
-            memberRepository.findById(user.getUserId()).ifPresent(member ->
-                    searchRepository.save(new Search(member, search))
-            );
+            searchService.saveSearch(user.getUserId(), search);
         }
 
         int offset = (Math.max(page, 1) - 1) * size;

--- a/src/main/java/sopt/jeolloga/exception/ErrorCode.java
+++ b/src/main/java/sopt/jeolloga/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     UNAUTHORIZED_HEADER(HttpStatus.UNAUTHORIZED, "요청 헤더가 올바르지 않는 토큰입니다."),
+    INVALID_JWT(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT입니다."),
 
     // 403 FORBIDDEN
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),

--- a/src/main/java/sopt/jeolloga/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sopt/jeolloga/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package sopt.jeolloga.exception;
 
+import io.jsonwebtoken.JwtException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -77,6 +78,20 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.UNAUTHORIZED;
         return ResponseEntity.status(errorCode.getStatus())
                 .body(new ErrorResponse(errorCode.getCode(), errorCode.getMsg()));
+    }
+
+    @ExceptionHandler(JwtException.class)
+    public ResponseEntity<ErrorResponse> handleJwtException(JwtException ex) {
+        ErrorCode errorCode = ErrorCode.INVALID_JWT;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(new ErrorResponse(errorCode.getCode(), errorCode.getMsg()));
+    }
+
+    @ExceptionHandler(JwtAuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleJwtAuthException(JwtAuthenticationException ex) {
+        ErrorCode errorCode = ErrorCode.UNAUTHORIZED;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(new ErrorResponse(errorCode.getCode(), ex.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/sopt/jeolloga/exception/JwtAuthenticationException.java
+++ b/src/main/java/sopt/jeolloga/exception/JwtAuthenticationException.java
@@ -1,0 +1,10 @@
+package sopt.jeolloga.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class JwtAuthenticationException extends AuthenticationException {
+    public JwtAuthenticationException(String msg) {
+        super(msg);
+    }
+}
+


### PR DESCRIPTION
## 📝 Work Description
- Issue close #39 

## 🔨 Changes
- 검색어 저장을 SearchService로 위임. 검색어 갯수가 10개가 넘는다면, 가장 오래된 검색어부터 제거 + 동일 검색어 입력시 기존 검색어 제거와 최신화
- 사용자별 검색어 리스트 반환

## 💡 To Reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * JWT 인증을 기반으로 사용자의 최근 검색어 목록을 조회할 수 있는 엔드포인트가 추가되었습니다.
  * 최근 검색어는 최대 10개까지 저장되며, 중복 검색어 입력 시 기존 기록이 갱신됩니다.

* **버그 수정**
  * 인증이 필요한 URL 패턴이 "/api/user/**"에서 "/user/**"로 변경되어, 보다 정확한 인증 처리가 이루어집니다.

* **리팩터링**
  * 검색어 저장 및 조회 로직이 SearchService로 일원화되어 코드 구조가 개선되었습니다.

* **예외 처리 개선**
  * JWT 관련 인증 예외 처리 로직이 추가되어, 유효하지 않은 토큰에 대한 명확한 에러 메시지와 상태 코드가 반환됩니다.
  * JWT 토큰 추출 시 누락 또는 비정상 토큰에 대해 예외가 발생하도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->