### PR TITLE
[feat] 위시리스트 반환

### DIFF
--- a/src/main/java/sopt/jeolloga/domain/templestay/api/dto/TemplestayPageRes.java
+++ b/src/main/java/sopt/jeolloga/domain/templestay/api/dto/TemplestayPageRes.java
@@ -9,10 +9,20 @@ public record TemplestayPageRes(
         int totalPages,
         boolean last,
         List<TemplestayRes> content
-        ) {
+) {
     public static TemplestayPageRes of(List<TemplestayRes> content, int page, int size, long totalElements) {
         int totalPages = (int) Math.ceil((double) totalElements / size);
-        boolean last = page >= totalPages;
-        return new TemplestayPageRes(page, size, totalElements, totalPages, last, content);
+
+        int safePage = Math.max(page, 1);
+        boolean last = totalPages == 0 || safePage >= totalPages;
+
+        return new TemplestayPageRes(
+                safePage,
+                size,
+                totalElements,
+                totalPages,
+                last,
+                content != null ? content : List.of()
+        );
     }
 }

--- a/src/main/java/sopt/jeolloga/domain/wishlist/api/WishlistController.java
+++ b/src/main/java/sopt/jeolloga/domain/wishlist/api/WishlistController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*;
 import sopt.jeolloga.common.dto.ApiResponse;
 import sopt.jeolloga.domain.auth.jwt.JwtCookieProvider;
 import sopt.jeolloga.domain.auth.jwt.JwtTokenGenerator;
+import sopt.jeolloga.domain.wishlist.api.dto.WishlistPageRes;
 import sopt.jeolloga.domain.wishlist.core.WishlistService;
 
 @RestController
@@ -43,5 +44,18 @@ public class WishlistController {
 
         wishlistService.deleteWishlist(userId, id);
         return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @GetMapping("/wish")
+    public ResponseEntity<ApiResponse<?>> getWishlist(
+            HttpServletRequest request,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "6") int size
+    ) {
+        String accessToken = jwtCookieProvider.extractAccessToken(request);
+        Long userId = jwtTokenGenerator.extractUserId(accessToken);
+
+        WishlistPageRes response = wishlistService.getWishlist(userId, page, size);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/sopt/jeolloga/domain/wishlist/api/dto/WishlistPageRes.java
+++ b/src/main/java/sopt/jeolloga/domain/wishlist/api/dto/WishlistPageRes.java
@@ -1,0 +1,18 @@
+package sopt.jeolloga.domain.wishlist.api.dto;
+
+import java.util.List;
+
+public record WishlistPageRes(
+        int currentPage,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean last,
+        List<WishlistRes> content
+) {
+    public static WishlistPageRes of(List<WishlistRes> content, int page, int size, long totalElements) {
+        int totalPages = (int) Math.ceil((double) totalElements / size);
+        boolean last = page >= totalPages;
+        return new WishlistPageRes(page, size, totalElements, totalPages, last, content);
+    }
+}

--- a/src/main/java/sopt/jeolloga/domain/wishlist/api/dto/WishlistPageRes.java
+++ b/src/main/java/sopt/jeolloga/domain/wishlist/api/dto/WishlistPageRes.java
@@ -12,7 +12,18 @@ public record WishlistPageRes(
 ) {
     public static WishlistPageRes of(List<WishlistRes> content, int page, int size, long totalElements) {
         int totalPages = (int) Math.ceil((double) totalElements / size);
-        boolean last = page >= totalPages;
-        return new WishlistPageRes(page, size, totalElements, totalPages, last, content);
+
+        int safePage = Math.max(page, 1);
+
+        boolean last = totalPages == 0 || safePage >= totalPages;
+
+        return new WishlistPageRes(
+                safePage,
+                size,
+                totalElements,
+                totalPages,
+                last,
+                content != null ? content : List.of()
+        );
     }
 }

--- a/src/main/java/sopt/jeolloga/domain/wishlist/api/dto/WishlistRes.java
+++ b/src/main/java/sopt/jeolloga/domain/wishlist/api/dto/WishlistRes.java
@@ -1,0 +1,12 @@
+package sopt.jeolloga.domain.wishlist.api.dto;
+
+public record WishlistRes(
+        Long templestayId,
+        String templeName,
+        String templestayName,
+        String region,
+        String type,
+        String imgUrl,
+        boolean wish
+) {
+}

--- a/src/main/java/sopt/jeolloga/domain/wishlist/core/WishlistService.java
+++ b/src/main/java/sopt/jeolloga/domain/wishlist/core/WishlistService.java
@@ -8,9 +8,13 @@ import sopt.jeolloga.domain.member.core.MemberRepository;
 import sopt.jeolloga.domain.templestay.Templestay;
 import sopt.jeolloga.domain.templestay.core.repository.TemplestayRepository;
 import sopt.jeolloga.domain.wishlist.Wishlist;
+import sopt.jeolloga.domain.wishlist.api.dto.WishlistPageRes;
+import sopt.jeolloga.domain.wishlist.api.dto.WishlistRes;
+import sopt.jeolloga.domain.wishlist.core.querydsl.WishlistCustomRepository;
 import sopt.jeolloga.exception.BusinessErrorCode;
 import sopt.jeolloga.exception.BusinessException;
 
+import java.util.List;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -20,6 +24,7 @@ public class WishlistService {
     private final MemberRepository memberRepository;
     private final TemplestayRepository templestayRepository;
     private final WishlistRepository wishlistRepository;
+    private final WishlistCustomRepository wishlistCustomRepository;
 
     @Transactional
     public void updateWishlist(Long userId, Long templestayId) {
@@ -54,5 +59,14 @@ public class WishlistService {
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.NOT_FOUND_WISHLIST));
 
         wishlistRepository.delete(wishlist);
+    }
+
+    public WishlistPageRes getWishlist(Long userId, int page, int size) {
+        int offset = (page - 1) * size;
+
+        List<WishlistRes> content = wishlistCustomRepository.findWishlistContent(userId, offset, size);
+        long total = wishlistCustomRepository.countWishlist(userId);
+
+        return WishlistPageRes.of(content, page, size, total);
     }
 }

--- a/src/main/java/sopt/jeolloga/domain/wishlist/core/querydsl/WishlistCustomRepository.java
+++ b/src/main/java/sopt/jeolloga/domain/wishlist/core/querydsl/WishlistCustomRepository.java
@@ -1,0 +1,10 @@
+package sopt.jeolloga.domain.wishlist.core.querydsl;
+
+import sopt.jeolloga.domain.wishlist.api.dto.WishlistRes;
+
+import java.util.List;
+
+public interface WishlistCustomRepository {
+    List<WishlistRes> findWishlistContent(Long userId, int offset, int limit);
+    long countWishlist(Long userId);
+}

--- a/src/main/java/sopt/jeolloga/domain/wishlist/core/querydsl/WishlistCustomRepositoryImpl.java
+++ b/src/main/java/sopt/jeolloga/domain/wishlist/core/querydsl/WishlistCustomRepositoryImpl.java
@@ -4,9 +4,6 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import sopt.jeolloga.domain.wishlist.api.dto.WishlistRes;
 
@@ -14,7 +11,7 @@ import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
-public class WishlistNativeRepositoryImpl implements WishlistCustomRepository {
+public class WishlistCustomRepositoryImpl implements WishlistCustomRepository {
 
     @PersistenceContext
     private final EntityManager em;

--- a/src/main/java/sopt/jeolloga/domain/wishlist/core/querydsl/WishlistCustomRepositoryImpl.java
+++ b/src/main/java/sopt/jeolloga/domain/wishlist/core/querydsl/WishlistCustomRepositoryImpl.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import sopt.jeolloga.domain.wishlist.api.dto.WishlistRes;
 
@@ -14,7 +15,7 @@ import java.util.List;
 public class WishlistCustomRepositoryImpl implements WishlistCustomRepository {
 
     @PersistenceContext
-    private final EntityManager em;
+    private EntityManager em;
 
     @Override
     public List<WishlistRes> findWishlistContent(Long userId, int offset, int limit) {

--- a/src/main/java/sopt/jeolloga/domain/wishlist/core/querydsl/WishlistNativeRepositoryImpl.java
+++ b/src/main/java/sopt/jeolloga/domain/wishlist/core/querydsl/WishlistNativeRepositoryImpl.java
@@ -1,0 +1,81 @@
+package sopt.jeolloga.domain.wishlist.core.querydsl;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import sopt.jeolloga.domain.wishlist.api.dto.WishlistRes;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class WishlistNativeRepositoryImpl implements WishlistCustomRepository {
+
+    @PersistenceContext
+    private final EntityManager em;
+
+    @Override
+    public List<WishlistRes> findWishlistContent(Long userId, int offset, int limit) {
+        String sql = """
+            SELECT 
+                t.id AS templestayId,
+                t.temple_name AS templeName,
+                t.organized_name AS templestayName,
+                f.region,
+                f.type,
+                i.img_url,
+                TRUE AS wish
+            FROM wishlist w
+            JOIN templestay t ON t.id = w.templestay_id
+            JOIN filter f ON f.templestay_id = t.id
+            LEFT JOIN (
+                SELECT templestay_id, MIN(id) AS min_id
+                FROM image
+                GROUP BY templestay_id
+            ) fi ON fi.templestay_id = t.id
+            LEFT JOIN image i ON i.id = fi.min_id
+            WHERE w.member_id = :userId
+            ORDER BY w.id DESC
+            LIMIT :limit OFFSET :offset
+        """;
+
+        Query query = em.createNativeQuery(sql)
+                .setParameter("userId", userId)
+                .setParameter("limit", limit)
+                .setParameter("offset", offset);
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> resultList = query.getResultList();
+
+        return resultList.stream().map(row ->
+                new WishlistRes(
+                        ((Number) row[0]).longValue(),
+                        (String) row[1],
+                        (String) row[2],
+                        (String) row[3],
+                        (String) row[4],
+                        (String) row[5],
+                        true
+                )
+        ).toList();
+    }
+
+    @Override
+    public long countWishlist(Long userId) {
+        String countSql = """
+            SELECT COUNT(*)
+            FROM wishlist
+            WHERE member_id = :userId
+        """;
+        Number result = (Number) em.createNativeQuery(countSql)
+                .setParameter("userId", userId)
+                .getSingleResult();
+
+        return result.longValue();
+    }
+}


### PR DESCRIPTION
## 📝 Work Description
- Issue close #47

## 🔨 Changes
- 사용자 검증 후 wishlist반환
- 지역과 유형은 템플스테이 정보 반환하는 로직과 같음
- 6개씩 페이징 처리

## 💡 To Reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 위시리스트를 페이지네이션하여 조회할 수 있는 엔드포인트가 추가되었습니다.
  * 각 위시리스트 항목에 사찰명, 템플스테이명, 지역, 유형, 이미지, 찜 여부 등의 정보가 포함됩니다.

* **버그 수정**
  * 페이지네이션 응답에서 페이지 번호, 마지막 페이지 여부, 빈 리스트 처리 등 일부 입력값과 출력값의 일관성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->